### PR TITLE
MarkovNetwork: Optimizing activate_network

### DIFF
--- a/MarkovNetwork/MarkovNetwork.py
+++ b/MarkovNetwork/MarkovNetwork.py
@@ -166,7 +166,7 @@ class MarkovNetwork(object):
                 for mg_input_id in reversed(mg_input_ids):
                     if self.states[mg_input_id]:
                         mg_input_index += marker
-                    marker = marker * 2
+                    marker *= 2
 
                 # Determine the corresponding output values for this Markov Gate
                 roll = np.random.uniform()  # sets a roll value


### PR DESCRIPTION
## What does this PR do?
This PR optimizes the `activate_network` method. It makes my simulations run slightly faster than 4x the original speed.

I have made a Cython version for it that runs 14x faster than the original Python code. If you have interest on it, just let me know and I'll send it to you as well.


## Where should the reviewer start?
Reading the `activate_network` method and making tests.


## How should this PR be tested?
I tested it checking if output and states were the same as the original version. Important to note that there is a random number generator inside `activate_network`, so you should set the seed before tests.


## Any background context you want to provide?
I was asked to optimize this on a freelance platform, and the person who hired me was kind enough to let me make the pull request.


## What are the relevant issues?
None


## Screenshots (if appropriate)
None


## Questions:

- Do the docs need to be updated? No
- Does this PR add new (Python) dependencies? No
